### PR TITLE
QoL change when scanning QRs

### DIFF
--- a/app/src/main/java/com/cmput301w23t09/qrhunter/qrcode/QRCodeDatabase.java
+++ b/app/src/main/java/com/cmput301w23t09/qrhunter/qrcode/QRCodeDatabase.java
@@ -398,7 +398,7 @@ public class QRCodeDatabase {
     }
     ArrayList<String> players = (ArrayList<String>) snapshot.get("players");
     try {
-      return new QRCode(hash, name, score, location, null, null, players);
+      return new QRCode(hash, name, score, location, new ArrayList<>(), new ArrayList<>(), players);
     } catch (ExecutionException | InterruptedException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
This pull request implements a small issue I missed during my review of #58.

The purpose of this pull request is to skip directly to the `DeleteQRCodeFragment` if the scanned `QRCode` is already owned by the player, rather than displaying the `AddQRCodeFragment` for a split second.

In addition, this pull request also fixes an issue in terms of figuring out what players scanned a QR, as it fetches the QR first to see if any data exists before creating a brand new instance. (the existing behaviour would always report that no players scanned the QR)